### PR TITLE
Heroku login command is out of date

### DIFF
--- a/account-setup.md
+++ b/account-setup.md
@@ -59,7 +59,7 @@ Next, we will need to log into our heroku account in this coding environment.
 **Next**, run the following command and enter your email address and heroku password when prompted for it.
 
 ```
-heroku login
+heroku login -i
 ```
 
 This step logs your computer into your heroku account.  Connecting your heroku account with your SSH keys will make it so you won't have to manually log into heroku in the future when using it.


### PR DESCRIPTION
When running `heroku login` it attempts to open up a web browser to login. This wont work when working with remote machines. The `-i` command will cause us to go through the proper "email" and "password" login flow.